### PR TITLE
Added . to "from .version import version"

### DIFF
--- a/akeneo/api.py
+++ b/akeneo/api.py
@@ -19,7 +19,7 @@ import requests
 from requests import Request
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
-from version import __version__
+from .version import __version__
 
 __all__ = ['AkeneoAPI']
 AKENEO_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'


### PR DESCRIPTION
I was having an issue where my interpreter couldn't find version.py when I was importing the akeneo module from another product